### PR TITLE
Install and Launch Update

### DIFF
--- a/Serial-install.sh
+++ b/Serial-install.sh
@@ -25,3 +25,15 @@ pip install pyserial
 echo '##install node dependecies'
 npm install sqlite3
 npm install 
+
+echo '##new terminal and  run npm'
+lxterminal -e "npm run start"& 
+
+echo '##new terminal and run python'
+lxterminal -e "python serial_sqlwriter.py"&
+
+echo '##launch chrome in kiosk mode'
+# Start Chromium in kiosk mode
+sed -i 's/"exited_cleanly":false/"exited_cleanly":true/' ~/.config/chromium/'Lo$
+sed -i 's/"exited_cleanly":false/"exited_cleanly":true/; s/"exit_type":"[^"]\+"$
+chromium-browser --disable-infobars --kiosk 'http://localhost:3000'

--- a/Serial-install.sh
+++ b/Serial-install.sh
@@ -5,12 +5,8 @@
 #######################################
 
 ## Update packages ##
-
 echo '##updating packages' 
 sudo apt-get update -y 
-
-echo '##upgrading all packages now...'
-sudo apt-get upgrade -y
 
 echo '##installing Node Js now..'
 curl -fsSL https://deb.nodesource.com/setup_10.x | sudo bash -
@@ -34,6 +30,7 @@ lxterminal -e "python serial_sqlwriter.py"&
 
 echo '##launch chrome in kiosk mode'
 # Start Chromium in kiosk mode
-sed -i 's/"exited_cleanly":false/"exited_cleanly":true/' ~/.config/chromium/'Lo$
-sed -i 's/"exited_cleanly":false/"exited_cleanly":true/; s/"exit_type":"[^"]\+"$
-chromium-browser --disable-infobars --kiosk 'http://localhost:3000'
+sed -i 's/"exited_cleanly":false/"exited_cleanly":true/' /home/pi/.config/chromium/Default/Preferences
+sed -i 's/"exit_type":"Crashed"/"exit_type":"Normal"/' /home/pi/.config/chromium/Default/Preferences
+
+/usr/bin/chromium-browser --noerrdialogs --disable-infobars --kiosk http://localhost:3000 &


### PR DESCRIPTION
I have provided an update for the Serial only version of PAPI. Essentially you run the install script and once everything has been installed. It will then launch the two-run commands and launch a chrome browser into kiosk mode full resolution. The next step for me is to figure out how to get install to run once on first boot and then always continue to run the startup and launch app piece every bootup.
Signed-off-by: Evilgeniusnerd <kd2ael@gmail.com>